### PR TITLE
Fix color profile on ci

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -3,20 +3,10 @@ package log
 import (
 	"io"
 	"os"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
 // singletons ftw?
 var Log Interface = New(os.Stderr)
-
-func init() {
-	// enable colored output on github actions et al
-	if os.Getenv("CI") != "" {
-		lipgloss.SetColorProfile(termenv.TrueColor)
-	}
-}
 
 // New creates a new logger.
 func New(w io.Writer) *Logger {

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -16,7 +16,10 @@ import (
 )
 
 func init() {
-	lipgloss.SetColorProfile(termenv.ANSI256)
+	// enable colored output on github actions et al
+	if os.Getenv("CI") != "" {
+		lipgloss.SetColorProfile(termenv.TrueColor)
+	}
 }
 
 type Pet struct {


### PR DESCRIPTION
Forcing color profile for ci should only occurs during internal tests, otherwise, any project using this library would have its own tests forced with it (which is usually not that they want :) )