### PR TITLE
Restore padding

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -21,5 +21,7 @@ func main() {
 	log.WithField("foo", "bar").Info("info with a more increased padding")
 	log.ResetPadding()
 	log.WithError(errors.New("some error")).Error("error")
+	log.RestorePadding()
+	log.WithField("foo", "bar").Info("info with a restored padding")
 	log.WithError(errors.New("some fatal error")).Fatal("fatal")
 }

--- a/entry.go
+++ b/entry.go
@@ -33,6 +33,11 @@ func (e *Entry) ResetPadding() {
 	e.Logger.ResetPadding()
 }
 
+// RestorePadding restore the padding previously resetted.
+func (e *Entry) RestorePadding() {
+	e.Logger.RestorePadding()
+}
+
 // IncreasePadding increases the padding 1 times.
 func (e *Entry) IncreasePadding() {
 	e.Logger.IncreasePadding()

--- a/interface.go
+++ b/interface.go
@@ -16,6 +16,7 @@ type Interface interface {
 	Errorf(string, ...interface{})
 	Fatalf(string, ...interface{})
 	ResetPadding()
+	RestorePadding()
 	IncreasePadding()
 	DecreasePadding()
 }

--- a/logger.go
+++ b/logger.go
@@ -62,15 +62,22 @@ func (f Fields) Names() (v []string) {
 
 // Logger represents a logger with configurable Level and Handler.
 type Logger struct {
-	mu      sync.Mutex
-	Writer  io.Writer
-	Level   Level
-	Padding int
+	mu              sync.Mutex
+	Writer          io.Writer
+	Level           Level
+	Padding         int
+	resettedPadding int
 }
 
 // ResetPadding resets the padding to default.
 func (l *Logger) ResetPadding() {
+	l.resettedPadding = l.Padding
 	l.Padding = defaultPadding
+}
+
+// RestorePadding restore the padding previously resetted.
+func (l *Logger) RestorePadding() {
+	l.Padding = l.resettedPadding
 }
 
 // IncreasePadding increases the padding 1 times.

--- a/pkg.go
+++ b/pkg.go
@@ -36,6 +36,11 @@ func ResetPadding() {
 	Log.ResetPadding()
 }
 
+// RestorePadding restore the padding previously resetted.
+func RestorePadding() {
+	Log.RestorePadding()
+}
+
 // IncreasePadding increases the padding 1 times.
 func IncreasePadding() {
 	Log.IncreasePadding()

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -50,6 +50,9 @@ func TestRootLogOptions(t *testing.T) {
 	log.IncreasePadding()
 	log.Info("increased")
 	log.ResetPadding()
+	log.Info("resetted")
+	log.RestorePadding()
+	log.Info("restored")
 	pet := &Pet{"Tobi", 3}
 	log.WithFields(pet).Info("add pet")
 	requireEqualOutput(t, out.Bytes())

--- a/testdata/TestRootLogOptions.golden
+++ b/testdata/TestRootLogOptions.golden
@@ -7,4 +7,6 @@
 [1;91m  ⨯[0m warn 1
 [1;94m  •[0m foo                                              [1;94mfoo[0m=bar
 [1;94m    •[0m increased
-[1;94m  •[0m add pet                                          [1;94mage[0m=3 [1;94mname[0m=Tobi
+[1;94m  •[0m resetted
+[1;94m    •[0m restored
+[1;94m    •[0m add pet                                        [1;94mage[0m=3 [1;94mname[0m=Tobi


### PR DESCRIPTION
Introduce a new `RestorePadding` method, the exact opposite of `ResetPadding`, which set the padding at the same value it was juste before resetting


```go
log.IncreasePadding()
log.IncreasePadding()
...

log.Info("some trivial info")

// Reset padding to highlight warning
log.ResetPadding()
log.Warn("be careful !!!")

// Restore padding to carry on as if nothing had happened
log.RestorePadding()

log.Info("some other trivial and boring info")
```