### PR TITLE
Entry WithoutPadding

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -18,6 +18,7 @@ func main() {
 	log.IncreasePadding()
 	log.WithField("foo", "bar").Info("info with increased padding")
 	log.IncreasePadding()
+	log.WithoutPadding().WithField("foo", "bar").Info("info without padding")
 	log.WithField("foo", "bar").Info("info with a more increased padding")
 	log.ResetPadding()
 	log.WithError(errors.New("some error")).Error("error")

--- a/entry.go
+++ b/entry.go
@@ -18,13 +18,15 @@ type Entry struct {
 	Fields  Fields  `json:"fields"`
 	Level   Level   `json:"level"`
 	Message string  `json:"message"`
+	Padding int
 	fields  []Fields
 }
 
 // NewEntry returns a new entry for `log`.
 func NewEntry(log *Logger) *Entry {
 	return &Entry{
-		Logger: log,
+		Logger:  log,
+		Padding: log.Padding,
 	}
 }
 
@@ -49,8 +51,9 @@ func (e *Entry) WithFields(fields Fielder) *Entry {
 	f = append(f, e.fields...)
 	f = append(f, fields.Fields())
 	return &Entry{
-		Logger: e.Logger,
-		fields: f,
+		Logger:  e.Logger,
+		Padding: e.Padding,
+		fields:  f,
 	}
 }
 
@@ -75,6 +78,12 @@ func (e *Entry) WithError(err error) *Entry {
 	}
 
 	return ctx
+}
+
+// WithoutPadding returns entry without padding set to false.
+func (e *Entry) WithoutPadding() *Entry {
+	e.Padding = defaultPadding
+	return e
 }
 
 // Debug level message.
@@ -146,6 +155,7 @@ func (e *Entry) finalize(level Level, msg string) *Entry {
 	return &Entry{
 		Logger:  e.Logger,
 		Fields:  e.mergedFields(),
+		Padding: e.Padding,
 		Level:   level,
 		Message: msg,
 	}

--- a/entry_test.go
+++ b/entry_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/matryer/is"
@@ -9,7 +10,7 @@ import (
 
 func TestEntry_WithFields(t *testing.T) {
 	is := is.New(t)
-	a := NewEntry(nil)
+	a := NewEntry(New(io.Discard))
 	is.Equal(a.Fields, nil)
 
 	b := a.WithFields(Fields{"foo": "bar"})
@@ -26,7 +27,7 @@ func TestEntry_WithFields(t *testing.T) {
 
 func TestEntry_WithField(t *testing.T) {
 	is := is.New(t)
-	a := NewEntry(nil)
+	a := NewEntry(New(io.Discard))
 	b := a.WithField("foo", "bar")
 	is.Equal(Fields{}, a.mergedFields())
 	is.Equal(Fields{"foo": "bar"}, b.mergedFields())
@@ -34,7 +35,7 @@ func TestEntry_WithField(t *testing.T) {
 
 func TestEntry_WithError(t *testing.T) {
 	is := is.New(t)
-	a := NewEntry(nil)
+	a := NewEntry(New(io.Discard))
 	b := a.WithError(fmt.Errorf("boom"))
 	is.Equal(Fields{}, a.mergedFields())
 	is.Equal(Fields{"error": "boom"}, b.mergedFields())
@@ -42,7 +43,7 @@ func TestEntry_WithError(t *testing.T) {
 
 func TestEntry_WithError_fields(t *testing.T) {
 	is := is.New(t)
-	a := NewEntry(nil)
+	a := NewEntry(New(io.Discard))
 	b := a.WithError(errFields("boom"))
 	is.Equal(Fields{}, a.mergedFields())
 	is.Equal(Fields{
@@ -53,10 +54,25 @@ func TestEntry_WithError_fields(t *testing.T) {
 
 func TestEntry_WithError_nil(t *testing.T) {
 	is := is.New(t)
-	a := NewEntry(nil)
+	a := NewEntry(New(io.Discard))
 	b := a.WithError(nil)
 	is.Equal(Fields{}, a.mergedFields())
 	is.Equal(Fields{}, b.mergedFields())
+}
+
+func TestEntry_WithoutPadding(t *testing.T) {
+	is := is.New(t)
+	log := New(io.Discard)
+
+	a := NewEntry(log)
+	is.Equal(defaultPadding, a.Padding)
+
+	log.IncreasePadding()
+	b := NewEntry(log)
+	is.Equal(defaultPadding+2, b.Padding)
+
+	c := b.WithoutPadding()
+	is.Equal(defaultPadding, c.Padding)
 }
 
 type errFields string

--- a/interface.go
+++ b/interface.go
@@ -5,6 +5,7 @@ type Interface interface {
 	WithFields(Fielder) *Entry
 	WithField(string, interface{}) *Entry
 	WithError(error) *Entry
+	WithoutPadding() *Entry
 	Debug(string)
 	Info(string)
 	Warn(string)

--- a/logger.go
+++ b/logger.go
@@ -94,7 +94,7 @@ func (l *Logger) handleLog(e *Entry) {
 	fmt.Fprintf(
 		l.Writer,
 		"%s %-*s",
-		style.Render(fmt.Sprintf("%*s", 1+l.Padding, level)),
+		style.Render(fmt.Sprintf("%*s", 1+e.Padding, level)),
 		l.rightPadding(names),
 		e.Message,
 	)
@@ -129,6 +129,11 @@ func (l *Logger) WithField(key string, value interface{}) *Entry {
 // WithError returns a new entry with the "error" set to `err`.
 func (l *Logger) WithError(err error) *Entry {
 	return NewEntry(l).WithError(err)
+}
+
+// WithoutPadding returns a new entry without padding.
+func (l *Logger) WithoutPadding() *Entry {
+	return NewEntry(l).WithoutPadding()
 }
 
 // Debug level message.

--- a/pkg.go
+++ b/pkg.go
@@ -61,6 +61,11 @@ func WithError(err error) *Entry {
 	return Log.WithError(err)
 }
 
+// WithoutPadding returns a new entry without padding.
+func WithoutPadding() *Entry {
+	return Log.WithoutPadding()
+}
+
 // Debug level message.
 func Debug(msg string) {
 	Log.Debug(msg)

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -49,6 +49,8 @@ func TestRootLogOptions(t *testing.T) {
 	log.WithField("foo", "bar").Info("foo")
 	log.IncreasePadding()
 	log.Info("increased")
+	log.WithoutPadding().Info("without padding")
+	log.Info("increased")
 	log.ResetPadding()
 	pet := &Pet{"Tobi", 3}
 	log.WithFields(pet).Info("add pet")

--- a/testdata/TestRootLogOptions.golden
+++ b/testdata/TestRootLogOptions.golden
@@ -7,4 +7,6 @@
 [1;91m  ⨯[0m warn 1
 [1;94m  •[0m foo                                              [1;94mfoo[0m=bar
 [1;94m    •[0m increased
+[1;94m  •[0m without padding
+[1;94m    •[0m increased
 [1;94m  •[0m add pet                                          [1;94mage[0m=3 [1;94mname[0m=Tobi


### PR DESCRIPTION
Maybe a better approach than https://github.com/caarlos0/log/pull/4

`Entry` struct  has his own `Padding` value, copied  from current `Logger` one during initialization. Applying a `WithoutPadding` method juste reset it to default value.

```
log.IncreasePadding()
log.IncreasePadding()
...

log.Info("some trivial info")

// Without padding to highlight warning
log.WithoutPadding.Warn("be careful !!!")

// Carry on as if nothing had happened
log.Info("some other trivial and boring info")
```